### PR TITLE
Bug/Class Label Issue

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,6 @@ train:
 		--config-path "config/train_config.yaml" \
 		--train-path "${path}/train.parquet" \
 		--test-path "${path}/test.parquet" \
-		--value-counts-path "${path}/value_counts.json" \
 		--label-names-path "data/label_names/ukhra_ra.jsonl" \
 		--model-dir "data/model/"
 

--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,7 @@ download_data:
 	wget -O data/raw/ukhra2018.xlsx https://hrcsonline.net/wp-content/uploads/2020/01/UKHRA2018_HRCS_public_dataset_v1_27Jan2020.xlsx
 	wget -O data/raw/ukhra2014.xlsx https://hrcsonline.net/wp-content/uploads/2018/01/UK_Health_Research_Analysis_Data_2014_public_v1_27Oct2015.xlsx
 	wget -O data/raw/nihr_all.parquet https://nihr.opendatasoft.com/api/explore/v2.1/catalog/datasets/nihr-summary-view/exports/parquet?lang=en&timezone=Europe%2FLondon
+	@echo "Data download complete!"
 
 .PHONY: build_dataset
 build_dataset:

--- a/src/preprocess.py
+++ b/src/preprocess.py
@@ -55,24 +55,19 @@ def split_data_frame(df: pd.DataFrame, category: str, test_size=0.2):
     return train, test
 
 
-def save_train_test_data(train, test, value_counts, output_dir):
+def save_train_test_data(train, test, output_dir):
     """
     Save training and test data to disk.
 
     Args:
         train (pd.DataFrame): Training data.
         test (pd.DataFrame): Test data.
-        value_counts (dict): Mapping of label to count in the dataset.
         output_dir (str): Output directory.
     """
     if not os.path.exists(output_dir):
         os.makedirs(output_dir)
     train.to_parquet(output_dir + '/train.parquet')
     test.to_parquet(output_dir + '/test.parquet')
-
-    # save value_counts
-    with open(output_dir+'/value_counts.json', 'w') as f:
-        json.dump(value_counts, f)
 
 
 @click.command()
@@ -101,14 +96,8 @@ def processing_pipeline(config, clean_data, output_dir):
             config['preprocess_settings']['test_train_split']
         )
 
-        # calculate the value counts for each label (to compare evaluating
-        # metrics against the distribution of labels)
-        data_exploded = data.explode(category)
-        value_counts = data_exploded[category].value_counts()
-        value_counts = value_counts.to_dict()
-
         output_sub_dir = f'{output_dir}/{category.lower()}'
-        save_train_test_data(train, test, value_counts, output_sub_dir)
+        save_train_test_data(train, test, output_sub_dir)
 
 
 if __name__ == "__main__":

--- a/src/train.py
+++ b/src/train.py
@@ -198,15 +198,13 @@ def train(
         logging_strategy=config['training_settings']['logging_strategy'],
     )
 
-    HRCS_values = [value/sum(HRCS_values) for value in HRCS_values]
-    HRCS_values = [1/value for value in HRCS_values]
-
-    # set class weights
-    class_weights = torch.tensor(HRCS_values, dtype=torch.float32).to(device)
-
     compute_metrics = prepare_compute_metrics(config)
     # initialize trainer depending on class weighting option
     if class_weighting:
+        total_count = sum(class_counts)
+        HRCS_values = [1/(value/total_count) for value in class_counts]
+        class_weights = torch.tensor(HRCS_values, dtype=torch.float32).to(device)
+
         trainer = WeightedTrainer(
             model=model,
             args=training_args,

--- a/src/train.py
+++ b/src/train.py
@@ -63,8 +63,7 @@ class WeightedTrainer(Trainer):
 
     def compute_loss(self, model, inputs, return_outputs=False):
         """ How the loss is computed by Trainer. By default, all models return
-        the loss in the first element. Subclass and override for custom
-        behavior.
+        the loss in the first element. Subclass and override for custom behavior.
         """
         labels = inputs.pop("labels")
         outputs = model(**inputs)
@@ -181,22 +180,9 @@ def train(
     model.to(device)
 
     # initialize training arguments
-    training_args = TrainingArguments(
-        learning_rate=config['training_settings']['learning_rate'],
-        num_train_epochs=config['training_settings']['num_train_epochs'],
-        per_device_train_batch_size=config['training_settings'][
-            'per_device_train_batch_size'
-        ],
-        per_device_eval_batch_size=config['training_settings'][
-            'per_device_eval_batch_size'
-        ],
-        weight_decay=config['training_settings']['weight_decay'],
-        report_to=config['training_settings']["report_to"],
-        save_strategy=config['training_settings']['save_strategy'],
-        save_total_limit=config['training_settings']['save_total_limit'],
-        output_dir=model_path,
-        logging_strategy=config['training_settings']['logging_strategy'],
-    )
+    settings = config['training_settings']
+    settings['output_dir'] = model_path
+    training_args = TrainingArguments(**config['training_settings'])
 
     compute_metrics = prepare_compute_metrics(config)
     # initialize trainer depending on class weighting option

--- a/src/train.py
+++ b/src/train.py
@@ -180,9 +180,22 @@ def train(
     model.to(device)
 
     # initialize training arguments
-    settings = config['training_settings']
-    settings['output_dir'] = model_path
-    training_args = TrainingArguments(**config['training_settings'])
+    training_args = TrainingArguments(
+        learning_rate=config['training_settings']['learning_rate'],
+        num_train_epochs=config['training_settings']['num_train_epochs'],
+        per_device_train_batch_size=config['training_settings'][
+            'per_device_train_batch_size'
+        ],
+        per_device_eval_batch_size=config['training_settings'][
+            'per_device_eval_batch_size'
+        ],
+        weight_decay=config['training_settings']['weight_decay'],
+        report_to=config['training_settings']["report_to"],
+        save_strategy=config['training_settings']['save_strategy'],
+        save_total_limit=config['training_settings']['save_total_limit'],
+        output_dir=model_path,
+        logging_strategy=config['training_settings']['logging_strategy'],
+    )
 
     compute_metrics = prepare_compute_metrics(config)
     # initialize trainer depending on class weighting option

--- a/src/train.py
+++ b/src/train.py
@@ -280,12 +280,10 @@ def prepare_compute_metrics(config):
 
             # Loop through each sample's logits
             for i, logit in enumerate(logits):
-                # Get the indices of the logits sorted by value in descending
-                # order
+                # Get the indices of the logits sorted by value in descending order
                 sorted_indices = np.argsort(logit)[::-1]
 
-                # Assign 1 to the top logits that exceed their respective
-                # thresholds
+                # Assign 1 to the top logits that exceed their respective thresholds
                 for rank, idx in enumerate(sorted_indices):
                     if logit[idx] > thresholds[rank]:
                         predictions[i, idx] = 1
@@ -310,21 +308,15 @@ def prepare_compute_metrics(config):
         f1 = f1_score(labels, predictions, average=None)
         precision = precision_score(labels, predictions, average=None)
         recall = recall_score(labels, predictions, average=None)
-        print(
-            {
-                "f1": f1,
-                "f1_macro": f1_macro,
-                "f1_micro": f1_micro,
-                "precision": precision,
-                "recall": recall}
-            )
-        return {
+        metrics = {
             "f1": f1,
             "f1_macro": f1_macro,
             "f1_micro": f1_micro,
             "precision": precision,
             "recall": recall
         }
+        print(metrics)
+        return metrics
 
     return compute_metrics
 

--- a/src/train.py
+++ b/src/train.py
@@ -376,22 +376,22 @@ def run_training(args):
     class_labels = list(train_data.columns[:-1])
     class_counts = np.sum(train_data[train_data.columns[:-1]].to_numpy(), axis=0)
 
-    #wandb.init(
-    #    project=config['wandb_settings']['project_name'],
-    #    config=config['training_settings']
-    #)
+    wandb.init(
+        project=config['wandb_settings']['project_name'],
+        config=config['training_settings']
+    )
 
-    #wandb.log({"model_path": model_path})
+    wandb.log({"model_path": model_path})
 
-    #class_weighting = config['training_settings']['class_weighting']
-    #metrics = train(
-    #    train_data,
-    #    test_data,
-    #    model_path=model_path,
-    #    config=config,
-    #    class_labels=class_labels,
-    #    class_weighting=class_weighting
-    #)
+    class_weighting = config['training_settings']['class_weighting']
+    metrics = train(
+        train_data,
+        test_data,
+        model_path=model_path,
+        config=config,
+        class_labels=class_labels,
+        class_weighting=class_weighting
+    )
 
     #plot_metrics(metrics, class_labels)
 

--- a/src/train.py
+++ b/src/train.py
@@ -362,7 +362,6 @@ def plot_metrics(metrics, class_labels, class_counts):
 
 
 def run_training(args):
-    print('Started')
     timestamp = pd.Timestamp.now().strftime("%Y%m%d%H%M%S")
     model_name = config['training_settings']['model']
     model_path = f'{args.model_dir}/{model_name}_{timestamp}'
@@ -389,11 +388,11 @@ def run_training(args):
         test_data,
         model_path=model_path,
         config=config,
-        class_labels=class_labels,
+        class_counts=class_counts,
         class_weighting=class_weighting
     )
 
-    #plot_metrics(metrics, class_labels)
+    plot_metrics(metrics, class_labels, class_counts)
 
 
 if __name__ == "__main__":
@@ -403,11 +402,6 @@ if __name__ == "__main__":
     dp = 'data/preprocessed'
     parser.add_argument('--train-path', type=str, default=f'{dp}/train.parquet')
     parser.add_argument('--test-path', type=str, default=f'{dp}/test.parquet')
-    parser.add_argument(
-        '--value-counts-path',
-        type=str,
-        default=f'{dp}/value_counts.json'
-    )
     parser.add_argument(
         '--label-names-path',
         type=str,


### PR DESCRIPTION
## Class Labelling Issues
Proposed changes that seek to resolve the label mismatch between the `value_counts` JSON file used as class labels in `train.py` and the actual order of classes in the parquet dataset. See issue https://github.com/wellcometrust/grant_hrcs_tagger/issues/10 for full investigation.

### Changes Made
The label mismatch issue is avoided by using the train and test dataframe column headers as class labels instead of the separate `value_counts.json` file, as these are already correctly ordered in the same lexicographical order as the data. Value counts are then explicitly calculated for both the train and test dataset in `test.py` using `np.sum()`. 

As value_counts code is no longer needed, code to generate, transform and use it has been removed from `preprocess.py` and `train.py`. This also has the added benefit of significantly reducing code complexity, and improving the robustness of the codebase.

To prevent leakage of assumption on underlying class distribution between training and test, now only the count of class occurrences in the training data is passed to the `WeightedTrainner` class. Alongside this the logic for calculating the class_weights tensor has been moved to inside the `if class_weighting:` block, so it is now only calculated if needed.

Modified W&B metrics logging to now log the class occurrence counts separately for the train, test datasets, instead of the sum of both as previously logged using `value_counts`. This will allow improved understanding of the size of each class in each dataset and make it easier to validate the train, test strategy used.

### Testing These Changes
Tested labelling is consistent and correct in all intermediate outputs and now appears in the expected lexicographic order in the W&B logs.

### Evaluation of Change Impact
To compare training logs in W&B with the original and new labels, a new run was performed using the same parameters as the old run. (30 epochs, batch size of 16, output weighting True).

These can be viewed in W&B:
- New: https://wandb.wellcome-data.org/wellcome-ml-team/grant_hrcs_tagger/runs/pe6li3ls
- Old: https://wandb.wellcome-data.org/wellcome-ml-team/grant_hrcs_tagger/runs/hvum3szd

Unfortunately comparing the value counts against the class labels shows no change, as these are correctly matched. There is however a statistically significant difference between the metric distribution between the two groups.

#### RA codes plotted against F1 for the original labelling:
![output](https://github.com/user-attachments/assets/f26c2b48-62e1-4644-81c8-987a47b037ca)
The above plot shows only a very weak correlation that is not statistically significant between occurrence of training data for a class and the F1 score. Meaning we can't reject the null hypothesis that the distribution of F1 scores is random, or that there is no correlation between the two.

R Coefficient: 0.18177960860695436
P Value: 0.21625730815412547

#### RA codes plotted against F1 for the new labelling:
![outputNew](https://github.com/user-attachments/assets/dc432aff-6d26-4b40-b5b4-b74775077a1a)
With the new labelling there is a statistically significant, moderate correlation between value count and F1 performance, which is more inline with expected behaviour. This suggests the issue for poor macro-F1 performance is the lack of training data for certain classes.

R Coefficient: 0.4326715660968124
P Value: 0.0021306723207720007

As expected no significant change in model performance was noted. 
