### PR TITLE
Fix flash attn uv sync

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,16 @@ dependencies = [
     "flash-attn==2.7.4.post1; sys_platform == 'linux'",
 ]
 
+[tool.uv.extra-build-dependencies]
+flash-attn = [
+    {requirement = "torch", match-runtime = true},
+    "setuptools>=81",
+    "wheel",
+]
+
+[tool.uv.extra-build-variables]
+flash-attn = {FLASH_ATTENTION_SKIP_CUDA_BUILD = "TRUE"}
+
 [tool.ruff]
 line-length = 88
 
@@ -50,13 +60,6 @@ select = [
     "D",
 ]
 ignore = ["D100", "D104", "E501"]
-
-[tool.uv.extra-build-dependencies]
-flash-attn = [
-    { requirement = "torch", match-runtime = true },
-    "setuptools>=81",
-    "wheel",
-]
 
 [tool.uv.sources]
 torch = [{ index = "pytorch-cu124", marker = "sys_platform == 'linux'" }]


### PR DESCRIPTION
## What does this change?

Instructs UV to ignore CUDA setup for flash-attn, assumtion is made that CUDA is installed separately with torch.

## How to test

Run uv sync for this project on a **Linux** system and verify installed packages work correctly.